### PR TITLE
Add notebook-shim 0.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,49 @@
+{% set name = "notebook-shim" %}
 {% set version = "0.2.2" %}
 
 package:
-  name: notebook-shim
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/n/notebook-shim/notebook_shim-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook_shim-{{ version }}.tar.gz
   sha256: 090e0baf9a5582ff59b607af523ca2db68ff216da0c69956b62cab2ef4fc9c3f
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps -vvv
 
 requirements:
   host:
-    - hatchling >=1.0
+    - python
+    - hatchling
     - pip
-    - python >=3.7
+    - setuptools
+    - wheel
+
   run:
+    - python
     - jupyter_server >=1.8,<3
-    - python >=3.7
 
 test:
   imports:
     - notebook_shim
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
-  home: https://github.com/jupyterlab/notebook_shim
+  home: https://github.com/jupyter/notebook_shim
   summary: A shim layer for notebook traits and config
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
+  description: |
+    This project provides a way for JupyterLab and other frontends to switch to Jupyter Server for their Python Web application backend.
+  doc_url: https://github.com/jupyter/notebook_shim/blob/main/README.md
+  dev_url: https://github.com/jupyter/notebook_shim
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Jira ticket:** [PKG-728](https://anaconda.atlassian.net/browse/PKG-728) (notebook-shim 0.2.2)

**The upstream data:**
Changelog: https://github.com/jupyter/notebook_shim/blob/v0.2.2/CHANGELOG.md
License: https://github.com/jupyter/notebook_shim/blob/v0.2.2/LICENSE
Requirements: https://github.com/jupyter/notebook_shim/blob/v0.2.2/pyproject.toml

**_Actions:_**

1. Skip `py<37`
2. Update the `script` line
3. Add missing packages to `host`, remove pinnings
4. Fix `python` in `host` and `run`
5. Update `home` url
6. Add `license_family`
7. Add a `description`
8. Add `dev_url` and `doc_url`

**_Notes:_**
 * **nbclassic 0.4.8** requires it.

**Package's statistics**
<details>

 * Priority  | effort:  | Category:  | subcategory:  | pkg_type: 
 * Outdated platfroms: 
 * Latest version: 
 * Release on PyPi:
    * version: 0.2.2
    * date: 2022-11-03T03:45:08
* [PyPi history](https://pypi.org/project/notebook-shim/#history)
 * Popularity: 
    * 3 months downloads: 
    * All time:  1248253 downloads -  notebook-shim  0.2.2  A shim layer for notebook traits and config  copy  

</details>

**Other checks:**

<details>


9. - [x] https://github.com/jupyter/notebook_shim is present
10. - [x] Check the pinnings
12. - [x] Additional research
    https://github.com/jupyter/notebook_shim/issues
    200
13. - [x] `dev_url` is present
    https://github.com/jupyter/notebook_shim
14. - [x] `doc_url` is present
    https://github.com/jupyter/notebook_shim/blob/main/README.md
15. - [x] Verify that the `build_number` is correct
16. - [x] has `setuptools`
17. - [x] has `wheel`
18. - [x] `pip` in test
19. - [x] Verify the test section
20. - [x] Verify if the package is `architecture specific`
21. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
22.  - [x] license_file: LICENSE is present
23. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

24. - [x] license_family BSD is present
</details>

