### PR TITLE
notebook-shim 0.2.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  # jupyter_server-1.13.5-pyhd3eb1b0_0 requires anyio >=3.1.0,<4 but it's not available on s390x
+  skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook-shim" %}
-{% set version = "0.2.3" %}
+{% set version = "0.2.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook_shim-{{ version }}.tar.gz
-  sha256: f69388ac283ae008cd506dda10d0288b09a017d822d5e8c7129a152cbd3ce7e9
+  sha256: b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6829](https://anaconda.atlassian.net/browse/PKG-6829)
- [Upstream repo](https://github.com/jupyter/notebook_shim/tree/v0.2.4)
- release-diff: https://github.com/jupyter/notebook_shim/compare/v0.2.3...v0.2.4
- requirements-tagged: https://github.com/jupyter/notebook_shim/blob/v0.2.4/pyproject.toml


### Explanation of changes:

- Skip s390x because of missing anyio >=3.2.0,<4 

[PKG-6829]: https://anaconda.atlassian.net/browse/PKG-6829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ